### PR TITLE
Increase SAV_MEM_BSZ to 1111111 bytes.

### DIFF
--- a/save_data.cpp
+++ b/save_data.cpp
@@ -26,7 +26,7 @@
 */
 
 
-#define SAV_MEM_BSZ    (250000)
+#define SAV_MEM_BSZ    (1111111)
 
 
 


### PR DESCRIPTION
On my 1104Z, this triples the speed of saving 24M points.