### PR TITLE
Add print shortcut to main window.

### DIFF
--- a/interface.cpp
+++ b/interface.cpp
@@ -1978,6 +1978,7 @@ void UI_Mainwindow::show_howto_operate()
     "Press 'c' to center the horizontal position.\n"
     "Press 't' to center the trigger position.\n"
     "Press 'f' to toggle FFT.\n"
+    "Press 'p' to save a screenshot.\n"
     );
 
   msgBox.exec();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -231,7 +231,8 @@ private:
           *select_chan4_act,
           *toggle_fft_act,
           *center_trigger_act,
-          *center_position_act;
+          *center_position_act,
+          *save_screenshot_act;
 
   struct tmcdev *device;
 

--- a/mainwindow_constr.cpp
+++ b/mainwindow_constr.cpp
@@ -509,6 +509,11 @@ UI_Mainwindow::UI_Mainwindow()
   toggle_fft_act = new QAction(this);
   toggle_fft_act->setShortcut(QKeySequence("f"));
   addAction(toggle_fft_act);
+  
+  save_screenshot_act = new QAction(this);
+  save_screenshot_act->setShortcut(QKeySequence("p"));
+  connect(save_screenshot_act, SIGNAL(triggered()), this, SLOT(save_screenshot()));
+  addAction(save_screenshot_act);
 
   DPRwidget->setEnabled(false);
 


### PR DESCRIPTION
This adds a shortcut to save a screenshot by pressing `p` in the main window.

It seems to me that there is another window (wave_dialog) where it could make sense to have also the shortcut.

I did not figure out where this windows can be openend and what it is about. Can you tell where to open this window?