### PR TITLE
add series 2 support

### DIFF
--- a/global.h
+++ b/global.h
@@ -189,10 +189,10 @@ struct device_settings
                                 // the screen is divided into 400 parts vertically which
                                 // are marked as 0 to 400 from top to bottom respectively
                                 // the range of <pos> is from 50 to 350
-  double math_decode_threshold[MAX_CHNS];  // 0: threshold of decode channel 1 (SPI:MISO for modelserie 6)
-                                           // 1: threshold of decode channel 2 (SPI:MOSI for modelserie 6)
-                                           // 2: threshold of decode channel 3 (SPI:SCLK for modelserie 6)
-                                           // 3: threshold of decode channel 4 (SPI:SS for modelserie 6)
+  double math_decode_threshold[MAX_CHNS];  // 0: threshold of decode channel 1 for series 1, PAR:THR/RS232:RTHR/SPI:SDA/SPI:MISO/IIC:SDA for series != 1
+                                           // 1: threshold of decode channel 2 for series 1, PAR:THR/RS232:TTHR/SPI:SCLK/SPI:MOSI/IIC:SCLK for series != 1
+                                           // 2: threshold of decode channel 3 for series 1, SPI:SCLK for series != 1
+                                           // 3: threshold of decode channel 4 for series 1, SPI:SS for series != 1
                                            // (-4 x VerticalScale - VerticalOffset) to
                                            // (4 x VerticalScale - VerticalOffset)
   double math_decode_threshold_uart_tx;    // threshold of RS232:TX for modelserie 6


### PR DESCRIPTION
The main difference between series 1 and the other is that series 1 decode values (position, threshold) are global while on the other series these are per bus decode protocol.

Series 2 decodes have been designed to work with two channel, leading to the SPI decode to only have SDA (for MISO and MOSI) and SCLK while on series designed for 4 channels have individual MISO, MOSI, SCLK, SS.

SPI decode display is not correct for series 2, and decodes other than UART/RS232 don't seem to be supported very well or at all.

The warning message because series 2 isn't recognized as support has not been removed.

This should fix issue #24 . No completed testing has been performed, but connection and display work.