### PR TITLE
continue readind TMC data when more is expected

### DIFF
--- a/tmc_dev.c
+++ b/tmc_dev.c
@@ -272,6 +272,17 @@ int tmcdev_read(struct tmcdev *dev)
 
   size2 = atoi(blockhdr + 2);
 
+  while(size < size2 && size<MAX_RESP_LEN) // we did not get all the data
+  {
+    ssize_t read_size = read(dev->fd, &dev->hdrbuf[size], MAX_RESP_LEN-size);
+    if(read_size < 1) // timeout or error occurred
+    {
+      blockhdr[31] = 0;
+      return -1;
+    }
+    size += read_size;
+  }
+
   size--;  // remove the last character
 
   if(size < size2)


### PR DESCRIPTION
When reading TMC data sometimes only 499 bytes are read, but more are available.
If more are expected the code tries to read the remaining.